### PR TITLE
Fix documentation about bucket name setting

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ Setting                Default                Description
 ===================    =================      ==================================================================
 **aws.access_key**     **required**           AWS access key
 **aws.secret_key**     **required**           AWS secret key
-**aws.bucket_name**    **required**           AWS bucket
+**aws.bucket**         **required**           AWS bucket
 **aws.acl**            ``public-read``        AWS ACL permissions
 **base_url**                                  Relative or absolute base URL for uploads; must end in slash ("/")
 **extensions**         ``default``            List of extensions or extension groups (see below)


### PR DESCRIPTION
Ref: https://github.com/danjac/pyramid_storage/blob/8739d572037a27145699724f13534641163e90f5/pyramid_storage/s3.py#L32