### PR TITLE
testing: Add DummyFileStorage.url

### DIFF
--- a/pyramid_storage/testing.py
+++ b/pyramid_storage/testing.py
@@ -1,12 +1,15 @@
 import os
 
+from pyramid import compat
+
 
 class DummyFileStorage(object):
     """A fake file storage object for testing. Instead of
     saving to file the filename is added to a list"""
 
-    def __init__(self):
+    def __init__(self, base_url="http://www.example.com"):
         self.saved = []
+        self.base_url = base_url
 
     def save(self, fs, folder=None, *args, **kwargs):
         """Performs a fake saved operation"""
@@ -14,3 +17,7 @@ class DummyFileStorage(object):
         name = os.path.join(folder or '', filename)
         self.saved.append(name)
         return name
+
+    def url(self, filename):
+        """Return a fake URL"""
+        return compat.urlparse.urljoin(self.base_url, filename)


### PR DESCRIPTION
Was running into issues due to the missing url method in my tests. Would be nice if we could add it.
