### PR TITLE
Add S3 async storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python: 2.7
 env:
     - TOX_ENV=py26
     - TOX_ENV=py27
-    - TOX_ENV=py35
-    - TOX_ENV=flake8
 before_install:
     # Travis has got a default config, that we override for our tests.
     # See: https://github.com/travis-ci/travis-ci/issues/7940

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    # Add an option to run the S3 integration tests, and have them normally
+    # skipped.
+    parser.addoption(
+        '--s3-integration',
+        action='store_true',
+        default=False,
+        help='run the integration tests',
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        'markers', 'integration: mark the test as an integration test'
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption('--s3-integration'):
+        # Run the integration tests
+        return
+
+    integration_skip = pytest.mark.skip(
+        reason='use --s3-integration option to run'
+    )
+    for item in items:
+        if 's3_integration' in item.keywords:
+            item.add_marker(integration_skip)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,14 @@ alternatively::
 
     config.include('pyramid_storage.s3')
 
+If you are configuring a pyramid async setup and require all drivers to be async aware, use::
+
+    pyramid.includes =
+        pyramid_storage.s3_async
+
+or::
+
+    config.include('pyramid_storage.s3_async')
 
 Configuration
 -------------
@@ -79,6 +87,30 @@ Setting                Default                Description
 **region**             ``None``               Region identifier, *host* and *port* will be ignored
 **num_retries**        ``1``                  Number of retry for connection errors
 **timeout**            ``5``                  HTTP socket timeout in seconds
+===================    =================      ==================================================================
+
+**S3 Async file storage**
+
+===================    =================      ==================================================================
+Setting                Default                Description
+===================    =================      ==================================================================
+**aws.access_key**     **required**           AWS access key
+**aws.secret_key**     **required**           AWS secret key
+**aws.bucket_name**    **required**           AWS bucket
+**aws.acl**            ``public-read``        `AWS ACL permissions <https://github.com/boto/boto/blob/v2.13.2/boto/s3/acl.py#L25-L28>`_
+**base_url**                                  Relative or absolute base URL for uploads; must end in slash ("/")
+**extensions**         ``default``            List of extensions or extension groups (see below)
+**name**               ``storage``            Name of property added to request, e.g. **request.storage**
+
+**use_path_style**     ``False``              Use paths for buckets instead of subdomains (useful for testing)
+**is_secure**          ``True``               Use ``https`` when a Host is defined
+**host**               ``None``               Host for Amazon S3 server (eg. `localhost`)
+**port**               ``None``               Port for Amazon S3 server (eg. `5000`)
+**region**             ``None``               Region identifier, *is_secure*, *host* and *port* will be ignored
+**num_retries**        ``5``                  Number of retry for connection errors
+**timeout**            ``5``                  HTTP socket connection timeout in seconds
+**read_timeout**       ``10``                 Timeout when reading from the HTTP socket in seconds
+**keepalive_timeout**  ``12``                 Number of seconds before closing the aiohttp Keep-Alive connection
 ===================    =================      ==================================================================
 
 **Google Cloud file storage**
@@ -246,6 +278,28 @@ Alternatively you can use the ``randomize`` argument to ensure a (near) unique f
 
 The  ``storage.base_url`` setting should be set to ``//s3amazonaws.com/<my-bucket-name>/`` unless you want to serve the file behind a proxy or through your Pyramid application.
 
+Usage: s3 async file storage
+----------------------
+
+.. warning::
+    S3 support requires you install the `aioboto3`_ and `aiofile`_ library separately (e.g. ``pip install aioboto3 aiofile``).
+
+    Alternatively you can install **pyramid_storage** with the mandatory extra dependencies: ``pip install pyramid_storage[s3_async]``
+
+.. warning::
+    It is the responsibility of the deployment team to ensure that the application has the correct AWS settings and permissions.
+
+Basic usage is similar to **S3FileStorage**, but every file operation must be await'ed::
+
+    from pyramid.view import view_config
+    from pyramid.httpexceptions import HTTPSeeOther
+
+    @view_config(route_name='upload',
+                 request_method='POST')
+    async def upload(request):
+        await request.storage.save(request.POST['my_file'])
+        return HTTPSeeOther(request.route_url('home'))
+
 Usage: Google Cloud Storage
 ---------------------------
 
@@ -330,6 +384,9 @@ API
 .. module:: pyramid_storage.s3
 
 .. autoclass:: S3FileStorage
+   :members:
+
+.. autoclass:: S3AsyncFileStorage
    :members:
 
 .. module:: pyramid_storage.gcloud

--- a/pyramid_storage/s3_async.py
+++ b/pyramid_storage/s3_async.py
@@ -1,0 +1,385 @@
+# -*- coding: utf-8 -*-
+
+import os
+import mimetypes
+
+from pyramid import compat
+from pyramid.settings import asbool
+from zope.interface import implementer
+
+from . import utils
+from .exceptions import FileNotAllowed
+from .extensions import resolve_extensions
+from .interfaces import IFileStorage
+from .registry import register_file_storage_impl
+
+try:
+    import aioboto3 as boto3
+
+    # aioboto3 uses aiobotocore, which uses botocore
+    from aiobotocore.config import AioConfig
+    from botocore import exceptions
+except ImportError:
+    # If any of the imports fail, set the globals
+    boto3 = None
+    AioConfig = None
+    exceptions = None
+
+try:
+    # The aiofile library is needed if opening local files (when using
+    # save_filename)
+    from aiofile import async_open
+except ImportError:
+    async_open = None
+
+
+def includeme(config):
+    if boto3 is None:
+        raise RuntimeError("You must have aioboto3 installed to use s3 async")
+
+    impl = S3AsyncFileStorage.from_settings(
+        config.registry.settings, prefix='storage.'
+    )
+
+    register_file_storage_impl(config, impl)
+
+
+@implementer(IFileStorage)
+class S3AsyncFileStorage(object):
+    @classmethod
+    def from_settings(cls, settings, prefix):
+        options = (
+            ('aws.bucket_name', True, None),
+            ('aws.acl', False, 'public-read'),
+            ('base_url', False, ''),
+            ('extensions', False, 'default'),
+            # S3 Connection options.
+            ('aws.access_key', False, None),
+            ('aws.secret_key', False, None),
+            ('aws.use_path_style', False, False),
+            ('aws.is_secure', False, True),
+            ('aws.host', False, None),
+            ('aws.port', False, None),
+            ('aws.region', False, None),
+            ('aws.num_retries', False, 5),
+            ('aws.timeout', False, 5),
+            ('aws.read_timeout', False, 10),
+            # aiobotocore additional options
+            # AWS has a 20 second idle timeout:
+            # https://forums.aws.amazon.com/message.jspa?messageID=215367
+            # and aiohttp default timeout is 30s so we set it to something
+            # aiobotocore default is 12
+            ('aws.keepalive_timeout', False, 12),
+        )
+        kwargs = utils.read_settings(settings, options, prefix)
+        kwargs = dict([(k.replace('aws.', ''), v) for k, v in kwargs.items()])
+
+        return cls(**kwargs)
+
+    def __init__(
+        self,
+        bucket_name,
+        acl=None,
+        base_url='',
+        extensions='default',
+        **connection_parameters
+    ):
+        self.bucket_name = bucket_name
+        self.acl = acl
+        self.base_url = base_url
+        self.extensions = resolve_extensions(extensions)
+        self.connection_parameters = connection_parameters
+        self._conn_options = None
+
+    @property
+    def conn_options(self):
+        '''Lazily create the connection options.'''
+        if not self._conn_options:
+            self._conn_options = self._get_connection_options(
+                **self.connection_parameters
+            )
+
+        return self._conn_options
+
+    @classmethod
+    def _make_aioconfig(
+        cls,
+        num_retries=None,
+        timeout=None,
+        read_timeout=None,
+        region=None,
+        use_dns_cache=None,
+        keepalive_timeout=None,
+        force_close=None,
+        use_path_style=False,
+    ):
+        """Create an AioConfig object (derived from botocore.config.Config)
+        for use with a client or resource for aioboto3.
+        """
+        if AioConfig is None:
+            raise RuntimeError(
+                "You must have aioboto3 installed to use s3 async"
+            )
+
+        num_retries = int(num_retries)
+        timeout = float(timeout)
+        read_timeout = float(read_timeout)
+
+        keepalive_timeout = float(keepalive_timeout)
+        addressing_style = 'path' if use_path_style else 'auto'
+
+        return AioConfig(
+            connect_timeout=timeout,
+            read_timeout=read_timeout,
+            region_name=region,
+            connector_args={
+                'keepalive_timeout': keepalive_timeout,
+            },
+            retries={
+                'max_attempts': num_retries,
+            },
+            s3={
+                'addressing_style': addressing_style,
+            },
+        )
+
+    @classmethod
+    def _get_connection_options(
+        cls,
+        is_secure=True,
+        host=None,
+        port=None,
+        secret_key=None,
+        access_key=None,
+        **kwargs  # additional args are passed to the AioConfig
+    ):
+        """Parses the kwargs provided for the client and returns the kwargs
+        the client or resource needs for boto3/aioboto3.
+        """
+        result = {
+            'config': cls._make_aioconfig(**kwargs),
+            'aws_access_key_id': access_key,
+            'aws_secret_access_key': secret_key,
+        }
+
+        if host is not None and not kwargs.get('region'):
+            protocol = 'https://' if asbool(is_secure) else 'http://'
+            parts = [protocol, host]
+            if port is not None:
+                parts.append(':')
+                parts.append(str(port))
+            result['endpoint_url'] = ''.join(parts)
+
+        return result
+
+    def s3_resource(self):
+        """Return an async context manager for interacting with S3.
+
+        Use like:
+            async with request.storage.s3_resource() as s3:
+                # do stuff
+                pass
+
+        The connection is automatically closed at the end of the block.
+        """
+        if boto3 is None:
+            raise RuntimeError(
+                "You must have aioboto3 installed to use s3 async"
+            )
+
+        return boto3.resource('s3', **self.conn_options)
+
+    def s3_client(self):
+        """Return an async context manager for for a lower-level S3 client."""
+        if boto3 is None:
+            raise RuntimeError(
+                "You must have aioboto3 installed to use s3 async"
+            )
+
+        return boto3.client('s3', **self.conn_options)
+
+    async def get_bucket(self, s3_resource):
+        """Given an s3 resource, returns the bucket.
+
+        Use like:
+            async with request.storage.s3_resource() as s3:
+                bucket = await request.storage.get_bucket(s3)
+                # do stuff
+
+        :param s3_resource: an opened s3_resource
+        """
+        return await s3_resource.Bucket(self.bucket_name)
+
+    def url(self, filename):
+        """Returns entire URL of the filename, joined to the base_url
+
+        :param filename: base name of file
+        """
+        return compat.urlparse.urljoin(self.base_url, filename)
+
+    async def exists(self, filename):
+        """Determine if a file exists.
+        This uses the head_object call on an S3 client to keep the server
+        costs as low as possible.
+
+        :param filename: name of the file
+        """
+        if exceptions is None:
+            raise RuntimeError(
+                "You must have aioboto3 installed to use s3 async"
+            )
+
+        async with self.s3_client() as s3_client:
+            try:
+                await s3_client.head_object(
+                    Bucket=self.bucket_name, Key=filename
+                )
+            except exceptions.ClientError as err:
+                if int(err.response.get('Error', {}).get('Code')) == 404:
+                    return False
+                raise
+
+            return True
+
+    async def delete(self, filename):
+        """Deletes the filename. Filename is resolved with the
+        absolute path based on base_path.
+
+        Always succeeds, even if file does not exist.
+
+        :param filename: base name of file
+        """
+        async with self.s3_resource() as s3:
+            file_object = await s3.Object(self.bucket_name, filename)
+            await file_object.delete()
+
+    def filename_allowed(self, filename, extensions=None):
+        """Checks if a filename has an allowed extension
+
+        :param filename: base name of file
+        :param extensions: iterable of extensions (or self.extensions)
+        """
+        _, ext = os.path.splitext(filename)
+        return self.extension_allowed(ext, extensions)
+
+    def file_allowed(self, fs, extensions=None):
+        """Checks if a file can be saved, based on extensions
+
+        :param fs: **cgi.FieldStorage** object or similar
+        :param extensions: iterable of extensions (or self.extensions)
+        """
+        return self.filename_allowed(fs.filename, extensions)
+
+    def extension_allowed(self, ext, extensions=None):
+        """Checks if an extension is permitted. Both e.g. ".jpg" and
+        "jpg" can be passed in. Extension lookup is case-insensitive.
+
+        :param extensions: iterable of extensions (or self.extensions)
+        """
+
+        extensions = extensions or self.extensions
+        if not extensions:
+            return True
+        if ext.startswith('.'):
+            ext = ext[1:]
+        return ext.lower() in extensions
+
+    async def save(self, fs, *args, **kwargs):
+        """Saves contents of a **cgi.FieldStorage** object to the file system.
+        Returns modified filename(including folder).
+
+        Returns the resolved filename, i.e. the folder + (modified/randomized)
+        filename.
+
+        :param fs: **cgi.FieldStorage** object (or similar). Can be a coroutine
+        :param folder: relative path of sub-folder
+        :param randomize: randomize the filename
+        :param extensions: iterable of allowed extensions, if not default
+        :param acl: ACL policy (if None then uses default)
+        :param replace: replace existing key
+        :param headers: dict of s3 request headers
+        :returns: modified filename
+        """
+        return await self.save_file(fs.file, fs.filename, *args, **kwargs)
+
+    async def save_filename(self, filename, *args, **kwargs):
+        """Saves a filename in local filesystem to the uploads location.
+        Requires the aiofile library to be installed.
+
+        Returns the resolved filename, i.e. the folder +
+        the (randomized/incremented) base name.
+
+        :param filename: local filename
+        :param folder: relative path of sub-folder
+        :param randomize: randomize the filename
+        :param extensions: iterable of allowed extensions, if not default
+        :param acl: ACL policy (if None then uses default)
+        :param replace: replace existing key
+        :param headers: dict of s3 request headers
+        :returns: modified filename
+        """
+        if async_open is None:
+            raise RuntimeError(
+                "You must have aiofile installed to use S3 async save_filename"
+            )
+
+        return await self.save_file(
+            async_open(filename, "rb"), filename, *args, **kwargs
+        )
+
+    async def save_file(
+        self,
+        file,
+        filename,
+        folder=None,
+        randomize=False,
+        extensions=None,
+        acl=None,
+        replace=False,
+        headers=None,
+    ):
+        """
+        :param filename: local filename
+        :param folder: relative path of sub-folder
+        :param randomize: randomize the filename
+        :param extensions: iterable of allowed extensions, if not default
+        :param acl: ACL policy (if None then uses default)
+        :param replace: replace existing key
+        :param headers: dict of s3 request headers
+        :returns: modified filename
+        """
+        acl = acl or self.acl
+        headers = headers or {}
+        extensions = extensions or self.extensions
+
+        if not self.filename_allowed(filename, extensions):
+            raise FileNotAllowed()
+
+        filename = utils.secure_filename(os.path.basename(filename))
+
+        if randomize:
+            filename = utils.random_filename(filename)
+
+        if folder:
+            filename = folder + "/" + filename
+
+        content_type = headers.get('Content-Type')
+        if content_type is None:
+            content_type, _ = mimetypes.guess_type(filename)
+            content_type = content_type or 'application/octet-stream'
+
+        async with self.s3_resource() as s3:
+            bucket = await self.get_bucket(s3)
+
+            file.seek(0)
+
+            await bucket.upload_fileobj(
+                file,
+                filename,
+                ExtraArgs={
+                    'ACL': acl,
+                    'ContentType': content_type,
+                },
+            )
+
+        return filename

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ docs_extras = [
 tests_require = [
     'pytest',
     'mock',
+    'pytest-mock',
+    'pytest-asyncio',
 ]
 
 
@@ -61,6 +63,7 @@ setup(
     extras_require={
         'docs': docs_extras,
         's3': ['boto'],
+        's3_async': ['aioboto3', 'aiofile'],
         'gcloud': ['google-cloud-storage'],
     },
     test_suite='pyramid_storage',

--- a/tests/test_s3_async.py
+++ b/tests/test_s3_async.py
@@ -1,0 +1,412 @@
+# -*- coding: utf-8 -*-
+import sys
+import mock
+import pytest
+
+import botocore.exceptions
+
+from pyramid import exceptions as pyramid_exceptions
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 5), reason='requires python3.5 or higher'
+)
+
+# Mock the AWS async resources that we'll be using
+# AsyncMock is available in Python 3.8, but to keep things working with older
+# versions, these explicit objects will provide the necessary mocking.
+
+
+class MockS3AsyncObject:
+    def __init__(self, bucket_name, filename):
+        self._bucket_name = bucket_name
+        self._filename = filename
+        self._deleted = False
+
+    async def delete(self):
+        self._deleted = True
+
+
+class MockS3AsyncBucket:
+    def __init__(self, name):
+        self._name = name
+        self._upload_fileobj_file = None
+        self._upload_fileobj_filename = None
+        self._upload_fileobj_call_args = None
+
+    async def upload_fileobj(self, file, filename, **kwargs):
+        self._upload_fileobj_file = file
+        self._upload_fileobj_filename = filename
+        self._upload_fileobj_call_args = kwargs
+        return None
+
+
+class MockS3AsyncResource:
+    def __init__(self):
+        self._file_object = None
+        self._bucket = None
+
+    async def Object(self, bucket_name, filename):
+        self._file_object = MockS3AsyncObject(bucket_name, filename)
+        return self._file_object
+
+    async def Bucket(self, bucket_name):
+        self._bucket = MockS3AsyncBucket(bucket_name)
+        return self._bucket
+
+
+class MockS3AsyncClient:
+    def __init__(self, make_object_missing=False):
+        self._make_object_missing = make_object_missing
+        self._head_object_kwargs = None
+
+    async def head_object(self, **kwargs):
+        self._head_object_kwargs = kwargs
+        if self._make_object_missing:
+            raise botocore.exceptions.ClientError(
+                operation_name='head_object',
+                error_response={
+                    'Error': {'Code': '404'},
+                },
+            )
+
+
+class MockAsyncContext:
+    def __init__(self, item):
+        self.item = item
+        self.called = False
+
+    async def __aenter__(self):
+        self.called = True
+        return self.item
+
+    async def __aexit__(self, exc_type, exc, tb):
+        assert not exc
+
+
+@pytest.fixture
+def mock_s3_client(mocker):
+    client = MockS3AsyncClient()
+    contextualized = MockAsyncContext(client)
+    mocker.patch(
+        'pyramid_storage.s3_async.S3AsyncFileStorage.s3_client',
+        return_value=contextualized,
+    )
+    return client
+
+
+@pytest.fixture
+def mock_s3_client_failure(mocker):
+    client = MockS3AsyncClient(make_object_missing=True)
+    contextualized = MockAsyncContext(client)
+    mocker.patch(
+        'pyramid_storage.s3_async.S3AsyncFileStorage.s3_client',
+        return_value=contextualized,
+    )
+    return client
+
+
+@pytest.fixture
+def mock_s3_resource(mocker):
+    resource = MockS3AsyncResource()
+    contextualized = MockAsyncContext(resource)
+    mocker.patch(
+        'pyramid_storage.s3_async.S3AsyncFileStorage.s3_resource',
+        return_value=contextualized,
+    )
+    return resource
+
+
+@pytest.fixture
+def mock_async_open(mocker):
+    mocker.patch(
+        'pyramid_storage.s3_async.async_open', return_value=mock.Mock()
+    )
+
+
+def test_extension_allowed_if_any():
+    from pyramid_storage import s3_async as s3
+
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="any",
+    )
+    assert s.extension_allowed(".jpg")
+
+
+def test_extension_allowed_if_allowed_if_dotted():
+    from pyramid_storage import s3_async as s3
+
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="images",
+    )
+    assert s.extension_allowed(".jpg", ("jpg",))
+
+
+def test_extension_not_allowed_if_allowed_if_dotted():
+    from pyramid_storage import s3_async as s3
+
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="images",
+    )
+    assert not s.extension_allowed("jpg", ("gif",))
+
+
+def test_extension_not_allowed_if_allowed_if_not_dotted():
+    from pyramid_storage import s3_async as s3
+
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="images",
+    )
+    assert not s.extension_allowed("jpg", ("gif",))
+
+
+def test_file_allowed():
+    from pyramid_storage import s3_async as s3
+
+    fs = mock.Mock()
+    fs.filename = "test.jpg"
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="images",
+    )
+
+    assert s.file_allowed(fs)
+
+
+def test_file_not_allowed():
+    from pyramid_storage import s3_async as s3
+
+    fs = mock.Mock()
+    fs.filename = "test.jpg"
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="documents",
+    )
+
+    assert not s.file_allowed(fs)
+
+
+@pytest.mark.asyncio
+async def test_save_if_file_not_allowed(mock_s3_resource):
+    from pyramid_storage import s3_async as s3
+    from pyramid_storage.exceptions import FileNotAllowed
+
+    fs = mock.Mock()
+    fs.filename = "test.jpg"
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="documents",
+    )
+
+    with pytest.raises(FileNotAllowed):
+        await s.save(fs)
+
+
+@pytest.mark.asyncio
+async def test_save_if_file_allowed(mock_s3_resource):
+    from pyramid_storage import s3_async as s3
+
+    fs = mock.Mock()
+    fs.filename = "test.jpg"
+
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="images",
+    )
+
+    name = await s.save(fs)
+    assert name == "test.jpg"
+
+
+@pytest.mark.asyncio
+async def test_save_file(mock_s3_resource):
+    from pyramid_storage import s3_async as s3
+
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="images",
+    )
+
+    name = await s.save_file(mock.Mock(), "test.jpg")
+    assert name == "test.jpg"
+
+
+@pytest.mark.asyncio
+async def test_save_filename(mock_s3_resource, mock_async_open):
+    from pyramid_storage import s3_async as s3
+
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="images",
+    )
+
+    name = await s.save_filename("test.jpg")
+    assert name == "test.jpg"
+
+
+@pytest.mark.asyncio
+async def test_save_if_randomize(mock_s3_resource):
+    from pyramid_storage import s3_async as s3
+
+    fs = mock.Mock()
+    fs.filename = "test.jpg"
+
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="images",
+    )
+
+    name = await s.save(fs, randomize=True)
+    assert name != "test.jpg"
+
+
+@pytest.mark.asyncio
+async def test_save_in_folder(mock_s3_resource):
+
+    from pyramid_storage import s3_async as s3
+
+    fs = mock.Mock()
+    fs.filename = "test.jpg"
+
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="images",
+    )
+
+    name = await s.save(fs, folder="my_folder")
+    assert name == "my_folder/test.jpg"
+
+
+@pytest.mark.asyncio
+async def test_save_with_content_type(mock_s3_resource):
+
+    from pyramid_storage import s3_async as s3
+
+    fs = mock.Mock()
+    fs.filename = "test.doc"
+
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="documents",
+    )
+
+    await s.save(fs, headers={"Content-Type": "text/html"})
+
+    call_args = mock_s3_resource._bucket._upload_fileobj_call_args
+    assert call_args["ExtraArgs"]["ContentType"] == "text/html"
+
+
+@pytest.mark.asyncio
+async def test_delete(mock_s3_resource):
+
+    from pyramid_storage import s3_async as s3
+
+    s = s3.S3AsyncFileStorage(
+        access_key="AK",
+        secret_key="SK",
+        bucket_name="my_bucket",
+        extensions="images",
+    )
+
+    await s.delete("test.jpg")
+    assert mock_s3_resource._file_object._deleted
+
+
+def test_from_settings_with_defaults():
+
+    from pyramid_storage import s3_async as s3
+
+    settings = {
+        'storage.aws.access_key': 'abc',
+        'storage.aws.secret_key': '123',
+        'storage.aws.bucket_name': 'Attachments',
+    }
+    inst = s3.S3AsyncFileStorage.from_settings(settings, 'storage.')
+    assert inst.base_url == ''
+    assert inst.bucket_name == 'Attachments'
+    assert inst.acl == 'public-read'
+    assert inst.conn_options['aws_access_key_id'] == 'abc'
+    assert inst.conn_options['aws_secret_access_key'] == '123'
+    assert set(('jpg', 'txt', 'doc')).intersection(inst.extensions)
+
+
+def test_from_settings_if_base_path_missing():
+
+    from pyramid_storage import s3_async as s3
+
+    with pytest.raises(pyramid_exceptions.ConfigurationError):
+        s3.S3AsyncFileStorage.from_settings({}, 'storage.')
+
+
+def test_from_settings_with_additional_options():
+
+    from pyramid_storage import s3_async as s3
+
+    settings = {
+        'storage.aws.access_key': 'abc',
+        'storage.aws.secret_key': '123',
+        'storage.aws.bucket_name': 'Attachments',
+        'storage.aws.is_secure': 'false',
+        'storage.aws.host': 'localhost',
+        'storage.aws.port': '5000',
+        'storage.aws.use_path_style': 'true',
+        'storage.aws.num_retries': '3',
+        'storage.aws.timeout': '20',
+        'storage.aws.read_timeout': '30',
+        'storage.aws.keepalive_timeout': '2',
+    }
+    inst = s3.S3AsyncFileStorage.from_settings(settings, 'storage.')
+
+    assert inst.conn_options['endpoint_url'] == 'http://localhost:5000'
+
+    config = inst.conn_options['config']
+    assert config.retries == {'max_attempts': 3}
+    assert config.connect_timeout == 20.0
+    assert config.read_timeout == 30.0
+    assert config.connector_args == {'keepalive_timeout': 2.0}
+
+
+def test_from_settings_with_regional_options_ignores_host_port():
+
+    from pyramid_storage import s3_async as s3
+
+    settings = {
+        'storage.aws.access_key': 'abc',
+        'storage.aws.secret_key': '123',
+        'storage.aws.bucket_name': 'Attachments',
+        'storage.aws.region': 'eu-west-1',
+        'storage.aws.host': 'localhost',
+        'storage.aws.port': '5000',
+    }
+    inst = s3.S3AsyncFileStorage.from_settings(settings, 'storage.')
+
+    assert 'endpoint_url' not in inst.conn_options

--- a/tests/test_s3_async_integration.py
+++ b/tests/test_s3_async_integration.py
@@ -1,0 +1,72 @@
+'''Perform an integration test with the S3 Async library.
+
+This requires Python 3.5+ as the async/await capabilities are unavailable
+in earlier versions.
+
+Set environment variables for the proper settings for the account to test.
+Use your own account credentials - these are examples and don't work.
+  export test_storage__aws__access_key=abc
+  export test_storage__aws__secret_key=123
+  export test_storage__aws__bucket_name=TestAttachments
+
+To test with a custom server or non-AWS service:
+  export test_storage__aws__is_secure=false
+  export test_storage__aws__host=localhost
+  export test_storage__aws__port=5000
+
+To test with AWS:
+  export test_storage__aws__region=eu-west-1
+
+
+Run this test with:
+  pytest --s3-integration
+'''
+
+import io
+import os
+
+import pytest
+
+from pyramid_storage import s3_async as s3
+
+KEY_PREFIX = 'test_storage.'
+
+
+@pytest.fixture
+def s3_settings():
+    # For testing, set variables in the environment with a
+    # "test_storage__" prefix
+    env_key_prefix = KEY_PREFIX.replace('.', '__')
+    return {
+        key.replace('__', '.'): value
+        for key, value in os.environ.items()
+        if key.startswith(env_key_prefix)
+    }
+
+
+@pytest.mark.s3_integration
+@pytest.mark.asyncio
+async def test_s3_async_integration(s3_settings):
+    inst = s3.S3AsyncFileStorage.from_settings(s3_settings, KEY_PREFIX)
+
+    test_filename = 'pyramid_storage_s3_async_test_file.txt'
+    test_file_content = b'This is a test file\n'
+    test_file = io.BytesIO(test_file_content)
+
+    assert not await inst.exists(test_filename)
+
+    # Create the file
+    await inst.save_file(test_file, test_filename)
+    assert await inst.exists(test_filename)
+
+    # Read the file
+    async with inst.s3_resource() as s3_resource:
+        bucket = await inst.get_bucket(s3_resource)
+        returned_file_content = io.BytesIO()
+        await bucket.download_fileobj(test_filename, returned_file_content)
+
+    assert test_file_content == returned_file_content.getvalue()
+
+    # Delete the file
+    await inst.delete(test_filename)
+    assert not await inst.exists(test_filename)

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,16 @@ skip_missing_interpreters = True
 deps=
     pytest
     mock
+    pytest-mock
     moto
     -e.[gcloud]
+    {py35,py36,py37}: pytest-asyncio
+    {py35,py36,py37}: aioboto3
 
-commands=py.test
+commands=
+# The async keyword is illegal in python 2 and these files don't parse.
+    {py26,py27}: py.test --ignore=tests/test_s3_async.py --ignore=tests/test_s3_async_integration.py
+    {py35,py36,py37}: py.test
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
In order to support Pyramid websockets, I'm changing to async versions of my libraries. This change adds an option to use S3 storage via async using the aioboto3 library.

In order to verify that it works properly with the aioboto3 library, this change also adds an integration test that can be optionally run after adding configuration variables to the local environment.